### PR TITLE
feat: Headerコンポーネントを追加して、layout.tsxに組み込んだ

### DIFF
--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -13,5 +13,5 @@ interface LayoutProps {
  * @returns {JSX.Element} - レイアウトコンポーネント
  */
 export default function Layout({ children }: LayoutProps): JSX.Element {
-  return <main className="flex flex-col items-center my-8 md:my-12">{children}</main>;
+  return <div className="flex flex-col items-center my-8 md:my-12">{children}</div>;
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased  text-gray-200 bg-neutral-900 select-none`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased text-gray-200 bg-neutral-900 select-none`}
       >
         <Header />
         <main className="mx-6 md:mx-10 lg:mx-20">{children}</main>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { JSX } from "react";
 import "./globals.css";
+import { Header } from "@/components/layout/header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -33,9 +34,10 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-neutral-900 text-gray-200 mx-6 md:mx-10 lg:mx-20`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased  text-gray-200 bg-neutral-900 select-none`}
       >
-        {children}
+        <Header />
+        <main className="mx-6 md:mx-10 lg:mx-20">{children}</main>
       </body>
     </html>
   );

--- a/frontend/src/components/layout/header/Header.tsx
+++ b/frontend/src/components/layout/header/Header.tsx
@@ -1,0 +1,25 @@
+import { Text } from "@/components/ui";
+import Link from "next/link";
+import { JSX } from "react";
+
+/**
+ * @description Headerコンポーネント
+ * @todo ナビゲーションメニューの実装
+ * @todo ユーザー情報の表示(現在は仮にGuestと表示している)
+ * @returns {JSX.Element}
+ */
+export default function Header(): JSX.Element {
+  return (
+    <header className="flex items-center justify-between p-2 md:p-4 border-b border-gray-600 text-gray-200">
+      <section>
+        <Link href={"/"} className="text-2xl  md:text-3xl font-bold cursor-pointer">
+          Portful
+        </Link>
+        <nav></nav>
+      </section>
+      <section>
+        <Text className="cursor-pointer">Guest</Text>
+      </section>
+    </header>
+  );
+}

--- a/frontend/src/components/layout/header/Header.tsx
+++ b/frontend/src/components/layout/header/Header.tsx
@@ -12,7 +12,7 @@ export default function Header(): JSX.Element {
   return (
     <header className="flex items-center justify-between p-2 md:p-4 border-b border-gray-600 text-gray-200">
       <section>
-        <Link href={"/"} className="text-2xl  md:text-3xl font-bold cursor-pointer">
+        <Link href={"/"} className="text-2xl md:text-3xl font-bold cursor-pointer">
           Portful
         </Link>
         <nav></nav>

--- a/frontend/src/components/layout/header/index.ts
+++ b/frontend/src/components/layout/header/index.ts
@@ -1,0 +1,1 @@
+export { default as Header } from "./Header";


### PR DESCRIPTION
## 内容
- Headerコンポーネントの作成
- roorのlayout.tsxにHeaderを組み込んだ+childrenをmainタグで囲んだ
- (auth)のlayout.tsxのchildrenを囲っているタグをmainタグからdivタグに変更した