### PR TITLE
refactor: select-noneをcomponents/uiから取り除いた

### DIFF
--- a/frontend/src/components/auth/shared/AuthInputField.tsx
+++ b/frontend/src/components/auth/shared/AuthInputField.tsx
@@ -46,7 +46,7 @@ export default function AuthInputField({
         className="w-56 sm:w-64 md:w-80 lg:w-96"
         {...register(id, registerOptions)}
       />
-      {errors?.message && <p className="text-red-500 text-sm mt-1 select-none">{errors.message}</p>}
+      {errors?.message && <p className="text-red-500 text-sm mt-1">{errors.message}</p>}
     </div>
   );
 }

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -19,7 +19,7 @@ export default function Button({ children, className, ...props }: ButtonProps): 
   return (
     <button
       className={cn(
-        "outline-none text-sm sm:text-base md:text-lg lg:text-xl xl:text-xl px-3 py-1 md:px-5 lg:px-6 lg:py-2 rounded-md border border-gray-700 hover:border-gray-400 bg-gray-800 opacity-80 hover:opacity-100 active:opacity-80 transition-opacity duration-200 ease-in-out cursor-pointer select-none",
+        "outline-none text-sm sm:text-base md:text-lg lg:text-xl xl:text-xl px-3 py-1 md:px-5 lg:px-6 lg:py-2 rounded-md border border-gray-700 hover:border-gray-400 bg-gray-800 opacity-80 hover:opacity-100 active:opacity-80 transition-opacity duration-200 ease-in-out cursor-pointer",
         className
       )}
       type="button"

--- a/frontend/src/components/ui/Label.tsx
+++ b/frontend/src/components/ui/Label.tsx
@@ -21,7 +21,7 @@ export default function Label({ children, className, ...props }: LabelProps): JS
   return (
     <label
       className={cn(
-        "text-sm sm:text-base md:text-lg lg:text-xl xl:text-xl px-2 py-1 md:px-4 lg:py-2 rounded-md cursor-pointer select-none",
+        "text-sm sm:text-base md:text-lg lg:text-xl xl:text-xl px-2 py-1 md:px-4 lg:py-2 rounded-md cursor-pointer",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/PageTitle.tsx
+++ b/frontend/src/components/ui/PageTitle.tsx
@@ -20,7 +20,7 @@ export default function PageTitle({ children, className, ...props }: PageTitlePr
   return (
     <h1
       className={cn(
-        "text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold mb-2 md:mb-3 lg:mb-4 select-none",
+        "text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold mb-2 md:mb-3 lg:mb-4",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/Text.tsx
+++ b/frontend/src/components/ui/Text.tsx
@@ -17,7 +17,7 @@ interface TextProps extends React.HTMLProps<HTMLParagraphElement> {
  */
 export default function Text({ children, className, ...props }: TextProps): JSX.Element {
   return (
-    <p className={cn("text-sm md:text-base lg:text-lg select-none", className)} {...props}>
+    <p className={cn("text-sm md:text-base lg:text-lg", className)} {...props}>
       {children}
     </p>
   );


### PR DESCRIPTION
## 内容
- bodyタグにselect-noneをつけたので、components/uiにつけていたselect-noneを削除した